### PR TITLE
チーム脱退機能実装 #5

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::Base
+    before_action :configure_permitted_parameters, if: :devise_controller?
+
+    private
+
+    def configure_permitted_parameters
+        added_attrs = [:email, :name, :password, :password_confirmation]
+        devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+        devise_parameter_sanitizer.permit :sign_in, keys: added_attrs
+    end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
     private
 
     def configure_permitted_parameters
-        added_attrs = [:email, :name, :password, :password_confirmation]
+        added_attrs = [:email, :name, :password, :password_confirmation, :image, :genre_id]
         devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
         devise_parameter_sanitizer.permit :sign_in, keys: added_attrs
     end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,7 +4,7 @@ class ApplicationController < ActionController::Base
     private
 
     def configure_permitted_parameters
-        added_attrs = [:email, :name, :password, :password_confirmation, :image, :genre_id]
+        added_attrs = [:email, :name, :password, :password_confirmation, :image, :genre_id, :goal]
         devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
         devise_parameter_sanitizer.permit :sign_in, keys: added_attrs
     end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -14,7 +14,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def create 
     super
     @join_team = TeamMember.new
-    @join_team.save(user_id: current_user.id, team_id: params[:team][:id])
+    @join_team.user_id = current_user.id
+    @join_team.team_id = params[:team][:id]
+    @join_team.save
   end
 
   # GET /resource/edit

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -5,14 +5,17 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
-  # def new
-  #   super
-  # end
+  def new
+    @teams = Team.all
+    super
+  end
 
   # POST /resource
-  # def create
-  #   super
-  # end
+  def create 
+    super
+    @join_team = TeamMember.new
+    @join_team.save(user_id: current_user.id, team_id: params[:team][:id])
+  end
 
   # GET /resource/edit
   # def edit

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+
+  def new_guest
+    user = User.guest
+    sign_in user
+    redirect_to root_path, notice: 'ゲストユーザーでログインしました。'
+  end
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,17 +1,27 @@
 class UsersController < ApplicationController
-
-  def edit
-  end
-
-  def update
-
-  end
-
   def show
     @user = User.find(params[:id])
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    @user.update(user_params)
+    redirect_to user_path(@user)
+
+  end
+
+
   def withdrawal
     
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:name, :email, :goal, :image, :genre_id)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -8,6 +8,7 @@ class UsersController < ApplicationController
   end
 
   def show
+    @user = User.find(params[:id])
   end
 
   def withdrawal

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,8 +1,13 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
-    team_id = TeamMember.find_by(user_id: @user.id).team_id
-    @join_team = Team.find(team_id)
+    # 簡潔な書き方があれば、後ほど修正する予定
+    unless TeamMember.find_by(user_id: @user.id).nil?
+      team_id = TeamMember.find_by(user_id: @user.id).team_id
+      @join_team = Team.find(team_id)
+    else
+      @join_team = nil
+    end
   end
 
   def edit
@@ -16,9 +21,12 @@ class UsersController < ApplicationController
 
   end
 
+  def confirmation
+    @user = User.find(current_user.id)
+  end
 
   def withdrawal
-    
+    join_team  = TeamMember.find_by(user_id: current_user.id).destroy
   end
 
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,8 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
+    team_id = TeamMember.find_by(user_id: @user.id).team_id
+    @join_team = Team.find(team_id)
   end
 
   def edit

--- a/app/models/genre.rb
+++ b/app/models/genre.rb
@@ -1,3 +1,3 @@
 class Genre < ApplicationRecord
-    has_many :teams
+    has_many :users
 end

--- a/app/models/team_member.rb
+++ b/app/models/team_member.rb
@@ -1,4 +1,4 @@
 class TeamMember < ApplicationRecord
-    belongs_to :user, class_name: "user", foreign_key: "user_id"
-    belongs_to :team, class_name: "team", foreign_key: "team_id"
+    belongs_to :user
+    belongs_to :team
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+
+  attachment :image
+
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
 
@@ -9,6 +12,7 @@ class User < ApplicationRecord
   has_many :team_members, dependent: :destroy
   has_many :training_records, dependent: :destroy
   has_many :post_messages, dependent: :destroy
+  belongs_to :genre
 
   def self.guest
     find_or_create_by!(email: 'guest@sample.com') do |user|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,10 @@ class User < ApplicationRecord
   has_many :team_members, dependent: :destroy
   has_many :training_records, dependent: :destroy
   has_many :post_messages, dependent: :destroy
+
+  def self.guest
+    find_or_create_by!(email: 'guest@sample.com') do |user|
+      user.password = SecureRandom.urlsafe_base64
+    end
+  end
 end

--- a/app/views/homes/top.html.slim
+++ b/app/views/homes/top.html.slim
@@ -2,3 +2,5 @@ h1
   | Homes#top
 p
   | Find me in app/views/homes/top.html.erb
+
+= link_to  "ゲストログイン", users_guest_sign_in_path, method: :post

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,6 +8,8 @@ html
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   body
+  header
+    = link_to  "ログアウト",  destroy_user_session_path, method: :delete
   p 
     = notice
     = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -9,6 +9,8 @@ html
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   body
   header
+    = link_to  "新規登録",  new_user_registration_path
+    = link_to  "ログイン", new_user_session_path
     = link_to  "ログアウト",  destroy_user_session_path, method: :delete
   p 
     = notice

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,4 +8,6 @@ html
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   body
+  p 
+    = notice
     = yield

--- a/app/views/users/confirmation.html.slim
+++ b/app/views/users/confirmation.html.slim
@@ -1,0 +1,9 @@
+h1
+    |チーム脱退確認画面
+
+p
+    |本当に脱退しますか??
+
+= link_to  "脱退する",  user_withdrawal_path(@user), method: :post
+br
+= link_to  "脱退しない",  user_path(@user)

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,4 +1,23 @@
 h1
   | Users#edit
-p
-  | Find me in app/views/users/edit.html.erb
+
+= form_with model:@user, local: true do |f|
+  = f.label :name
+  br/
+  = f.text_field :name
+  br/
+  = f.label :goal
+  br/
+  = f.text_field :goal
+  br/
+  = f.label :genre
+  br/
+  = f.select :genre, [['筋トレ', 1],['シェイプアップ', 2],['脱メタボ', 3]]
+  br/
+  = f.label :email
+  = f.email_field :email
+  br/
+  = f.label :image
+  = f.attachment_field :image
+  br/
+  = f.submit '更新'

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -17,6 +17,11 @@ h2
     = f.select :genre_id, [['筋トレ', 1], ['シェイプアップ', 2], ['脱メタボ', 3]]
 
   .field
+    = f.label :goal
+    br/
+    = f.text_field  :goal
+
+  .field
     = f.label :email
     br
     = f.email_field :email, autocomplete: "email"

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -11,7 +11,14 @@ h2
     br
     = f.text_field :name, autofocus: true
   
-  .field
+  .field 
+  p
+    | 所属するチーム
+    br
+      = collection_select(:team, :id, @teams, :id, :name)
+
+    
+    
     = f.label :genre_id
     br
     = f.select :genre_id, [['筋トレ', 1], ['シェイプアップ', 2], ['脱メタボ', 3]]

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -4,9 +4,17 @@ h2
   = render "users/shared/error_messages", resource: resource
 
   .field
+    = f.attachment_field :image
+
+  .field
     = f.label :name
     br
-    = f.text_field :name, autofocus: true 
+    = f.text_field :name, autofocus: true
+  
+  .field
+    = f.label :genre_id
+    br
+    = f.select :genre_id, [['筋トレ', 1], ['シェイプアップ', 2], ['脱メタボ', 3]]
 
   .field
     = f.label :email

--- a/app/views/users/registrations/new.html.slim
+++ b/app/views/users/registrations/new.html.slim
@@ -2,10 +2,16 @@ h2
   | Sign up
 = form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f|
   = render "users/shared/error_messages", resource: resource
+
+  .field
+    = f.label :name
+    br
+    = f.text_field :name, autofocus: true 
+
   .field
     = f.label :email
     br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
+    = f.email_field :email, autocomplete: "email"
   .field
     = f.label :password
     - if @minimum_password_length

--- a/app/views/users/sessions/new.html.slim
+++ b/app/views/users/sessions/new.html.slim
@@ -2,9 +2,9 @@ h2
   | Log in
 = form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
   .field
-    = f.label :email
+    = f.label :name
     br
-    = f.email_field :email, autofocus: true, autocomplete: "email"
+    = f.text_field :name, autofocus: true, autocomplete: "name"
   .field
     = f.label :password
     br

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -14,4 +14,8 @@ br/
 p
   | 所属しているチーム
   br
-  = @join_team.name
+  - if @join_team.nil?
+    p
+      | 所属なし
+  - else
+      = @join_team.name

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -7,5 +7,7 @@ br/
 br/
 = @user.email
 br/
+= @user.goal
+br/
 = attachment_image_tag @user, :image, :fill, 300, 300, format: 'jpeg'
 br/

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -1,4 +1,11 @@
 h1
   | Users#show
-p
-  | Find me in app/views/users/show.html.erb
+
+= @user.name
+br/
+= @user.genre.name
+br/
+= @user.email
+br/
+= attachment_image_tag @user, :image, :fill, 300, 300, format: 'jpeg'
+br/

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -11,3 +11,7 @@ br/
 br/
 = attachment_image_tag @user, :image, :fill, 300, 300, format: 'jpeg'
 br/
+p
+  | 所属しているチーム
+  br
+  = @join_team.name

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the
@@ -244,7 +244,7 @@ Devise.setup do |config|
   # Turn scoped views on. Before rendering "sessions/new", it will first check for
   # "users/sessions/new". It's turned off by default because it's slower if you
   # are using only default views.
-  # config.scoped_views = false
+  config.scoped_views = true
 
   # Configure the default scope given to Warden. By default it's the first
   # devise role declared in your routes (usually :user).

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,7 +16,11 @@ Rails.application.routes.draw do
     resources :post_messages, only: [:create, :destroy]
     resources :bookmarks, only: [:create, :destroy]
     resources :training_records, only: [:new, :create, :edit, :update, :destroy]
+    get 'confirmation' => 'users#confirmation'
+    post 'withdrawal' => 'users#withdrawal'
+    patch 'withdrawal' => 'users#withdrawal'
   end
+  
   resources :teams
   resource  :inquiries, only: [:create]
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
               registrations: 'users/registrations',
             }
 
+  devise_scope :user do
+    post 'users/guest_sign_in', to: 'users/sessions#new_guest'
+  end
+
   resources :users, only: [:show, :edit, :update] do
     resources :post_messages, only: [:create, :destroy]
     resources :bookmarks, only: [:create, :destroy]


### PR DESCRIPTION
・新規ユーザー登録時に、所属するチームも合わせて登録するように実装
・どこにも所属していないときには、ユーザーページにて「所属なし」と表示
・チーム脱退確認画面から脱退アクションまで実装